### PR TITLE
Add roundTab component

### DIFF
--- a/web/src/components/tab/RoundTab.tsx
+++ b/web/src/components/tab/RoundTab.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useState } from "react";
+
+interface RoundTabViewProps {
+  children?: React.ReactNode;
+}
+
+const RoundTabView = ({ children }: RoundTabViewProps) => {
+  // TODO 마크업 필요
+  return <div className="tab-container">{children}</div>;
+};
+
+interface RoundTabProps {
+  children?: React.ReactNode;
+}
+
+export default function RoundTab({ children }: RoundTabProps) {
+  const viewProps = { children };
+
+  const [activeTabIdx, setActiveTabIdx] = useState<number>(0);
+
+  return (
+    <RoundTabContext.Provider value={{ activeTabIdx, setActiveTabIdx }}>
+      <RoundTabView {...viewProps} />
+    </RoundTabContext.Provider>
+  );
+}
+
+interface RoundTabContextType {
+  activeTabIdx: number;
+  setActiveTabIdx: (idx: number) => void;
+}
+
+export const RoundTabContext = createContext<RoundTabContextType>({
+  activeTabIdx: 0,
+  setActiveTabIdx: () => {},
+});

--- a/web/src/components/tab/RoundTabItem.tsx
+++ b/web/src/components/tab/RoundTabItem.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { RoundTabContext } from "./RoundTab";
+
+/**
+ * round 형태의 탭을 정의하는 컴포넌트입니다.
+ * RoundTabItemPanel과 함께 사용됩니다. (화면 정의시 사용)
+ */
+interface RoundTabItemViewProps {
+  label: string;
+  onClick: () => void;
+}
+
+const RoundTabItemView = ({ label, onClick }: RoundTabItemViewProps) => {
+  // 마크업 수정 필요
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        background: "black",
+        color: "white",
+        marginRight: "5px",
+        padding: "10px",
+        borderRadius: "10px",
+      }}
+    >
+      {label}
+    </div>
+  );
+};
+
+interface RoundTabItemProps {
+  label: string;
+  index: number;
+}
+
+export default function RoundTabItem({ label, index }: RoundTabItemProps) {
+  const viewProps = { label };
+
+  return (
+    <RoundTabContext.Consumer>
+      {({ setActiveTabIdx }) => {
+        const handleClick = () => setActiveTabIdx(index);
+        return <RoundTabItemView {...viewProps} onClick={handleClick} />;
+      }}
+    </RoundTabContext.Consumer>
+  );
+  // return <RoundTabItemView {...viewProps} />;
+}

--- a/web/src/components/tab/RoundTabList.tsx
+++ b/web/src/components/tab/RoundTabList.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+interface RoundTabListViewProps {
+  children: React.ReactNode;
+}
+
+const RoundTabListView = ({ children }: RoundTabListViewProps) => {
+  return (
+    <div
+      className="tab-container"
+      style={{ display: "flex", position: "relative" }}
+    >
+      {children}
+    </div>
+  );
+};
+
+interface RoundTabListProps {
+  children?: React.ReactNode;
+}
+
+export default function RoundTabList({ children }: RoundTabListProps) {
+  const viewProps = { children };
+
+  return <RoundTabListView {...viewProps} />;
+}

--- a/web/src/components/tab/RoundTabPanel.tsx
+++ b/web/src/components/tab/RoundTabPanel.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { RoundTabContext } from "./RoundTab";
+
+interface RoundTabPanelViewProps {
+  children?: React.ReactNode;
+}
+
+const RoundTabPanelView = ({ children }: RoundTabPanelViewProps) => {
+  return <div>{children}</div>;
+};
+
+interface RoundTabPanelProps {
+  children?: React.ReactNode;
+  index: number; // tabItem의 index 순서 매칭용 (0부터 시작)
+}
+
+export default function RoundTabPanel({ children, index }: RoundTabPanelProps) {
+  const viewProps = { children };
+
+  return (
+    <RoundTabContext.Consumer>
+      {({ activeTabIdx }) =>
+        activeTabIdx === index && <RoundTabPanelView {...viewProps} />
+      }
+    </RoundTabContext.Consumer>
+  );
+}

--- a/web/src/stories/Dev/Tab/RoundTab.stories.tsx
+++ b/web/src/stories/Dev/Tab/RoundTab.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import RoundTab from "@/components/tab/RoundTab";
+import RoundTabItem from "@/components/tab/RoundTabItem";
+import RoundTabList from "@/components/tab/RoundTabList";
+import RoundTabPanel from "@/components/tab/RoundTabPanel";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: "Dev/Tab",
+  component: RoundTab,
+  parameters: {
+    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+    layout: "centered",
+  },
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  argTypes: {},
+  decorators: [(story) => <div style={{ margin: "3rem" }}>{story()}</div>],
+} satisfies Meta<typeof RoundTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+
+export const TabList: Story = {
+  args: {},
+  render: (args) => (
+    <RoundTab>
+      <RoundTabList {...args}>
+        <RoundTabItem label="tab1" index={0} />
+        <RoundTabItem label="tab2" index={1} />
+        <RoundTabItem label="tab3" index={2} />
+      </RoundTabList>
+      <RoundTabPanel index={0}>tab panel1</RoundTabPanel>
+      <RoundTabPanel index={1}>tab panel2</RoundTabPanel>
+      <RoundTabPanel index={2}>tab panel3</RoundTabPanel>
+    </RoundTab>
+  ),
+};


### PR DESCRIPTION
@yeorimkim 님 탭 UI가 추가되어서 기능개발 먼저 되어야 마크업 작업하시기 수월 하실 것 같아서
`roundTab` 이라고 컴포넌트들을 만들어두었습니당

아래처럼 쓰시면 되고 내부에 마크업은 다 추가되어야 해요!!!
구조는 이렇게 가져가돼 이 컴포넌트들 `View` 함수들 (ex- `RoundTabView`)부분에 직접 마크업 수정해주셔도 되고, 활용해서 component/markup 단에 새로 파일 만들어서 쓰셔도됩니당

### 사용법
- `RoundTab.stories.tsx` 참고하시면 됩니다.
```
    <RoundTab>
      <RoundTabList {...args}>
        <RoundTabItem label="tab1" index={0} />
        <RoundTabItem label="tab2" index={1} />
        <RoundTabItem label="tab3" index={2} />
      </RoundTabList>
      <RoundTabPanel index={0}>tab panel1</RoundTabPanel>
      <RoundTabPanel index={1}>tab panel2</RoundTabPanel>
      <RoundTabPanel index={2}>tab panel3</RoundTabPanel>
    </RoundTab>
```
<img width="893" alt="image" src="https://github.com/user-attachments/assets/7d504191-597f-4ca0-99e7-d29d2ff8da9d">


### 예상 사용처
<img width="443" alt="image" src="https://github.com/user-attachments/assets/bc1498a9-a4d4-4a1b-ae94-a1a78404ecba">
<img width="419" alt="image" src="https://github.com/user-attachments/assets/a152f8a2-87cd-470a-81b5-7274b579bdf3">
