### PR TITLE
[Markup] Calendar Page

### DIFF
--- a/web/.storybook/storybook.css
+++ b/web/.storybook/storybook.css
@@ -8,6 +8,6 @@
 #storybook-root {
   width: 100%;
   min-height: 100%;
-  background: #141414;
+  background: #0f0f0f;
   padding: 0 !important;
 }

--- a/web/src/markup/components/ButtonView.tsx
+++ b/web/src/markup/components/ButtonView.tsx
@@ -8,12 +8,35 @@ export interface ButtonProps {
   label: string;
   primary?: boolean;
   disabled?: boolean;
+  as?: "button" | "a";
+  href?: string;
 }
 
-export const Button = ({ label, primary = false, disabled }: ButtonProps) => {
-  const buttonMode = primary ? 'button-primary' : 'button-secondary';
+export const Button = ({
+  label,
+  primary = false,
+  disabled,
+  as = "button",
+  href,
+}: ButtonProps) => {
+  const buttonMode = primary ? "button-primary" : "button-secondary";
+
+  if (as === "a") {
+    return (
+      <a href={href} className={cn("button", buttonMode)}>
+        {label}
+      </a>
+    );
+  }
+
   return (
-    <button type="button" className={cn("button", buttonMode)} disabled={disabled}>{label}</button>
+    <button
+      type="button"
+      className={cn("button", buttonMode)}
+      disabled={disabled}
+    >
+      {label}
+    </button>
   );
 };
 

--- a/web/src/markup/components/SummaryView.tsx
+++ b/web/src/markup/components/SummaryView.tsx
@@ -11,6 +11,7 @@ export interface SummaryProps extends BadgeProps {
   text: string;
   typeFull: boolean;
   missionTexts: string[];
+  imgSrc: string;
 }
 
 export const Summary = ({
@@ -18,7 +19,8 @@ export const Summary = ({
   typeFull,
   missionTexts,
   status,
-  statusText
+  statusText,
+  imgSrc,
 }: SummaryProps) => {
   return (
     <div className={cn("summary-wrap", { "type-full": typeFull })}>
@@ -28,8 +30,8 @@ export const Summary = ({
           <p className={cn("text")}>{text}</p>
         </div>
         <div className={cn("image-wrap")}>
-          <Image 
-            src="https://picsum.photos/200" // Dummy Image
+          <Image
+            src={imgSrc}
             alt=""
             {...(typeFull ? { fill: true } : { width: 83, height: 83 })}
           />
@@ -47,17 +49,7 @@ export const Summary = ({
             {mission}
           </em>
         ))}
-      </div> 
-      {typeFull && (
-        <button type="button" className={cn("btn-more")} aria-label="옵션 (수정/삭제)">
-          <Image
-            src={`${basePath}/img/icon-dots.svg`}
-            width={17}
-            height={18}
-            alt=""
-          />
-        </button>
-      )}
+      </div>
     </div>
   );
 };

--- a/web/src/markup/pages/Calendar/MonthlyMission.tsx
+++ b/web/src/markup/pages/Calendar/MonthlyMission.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import CalendarHeaderView from "@/markup/components/calendar/CalendarHeaderView";
+import MonthlyCalendarView from "@/markup/components/calendar/MonthlyCalendarView";
+import SubTab from "@/markup/components/SubTab";
+import dayjs from "dayjs";
+import MissionSummary from "@/markup/components/SummaryView";
+
+const CalendarMonthlyMission = () => {
+  return (
+    <div className="wrap">
+      <main className="main">
+        <div className="contents">
+          <div className="calendar-area">
+            <CalendarHeaderView
+              type="monthly"
+              year={2024}
+              month={12}
+              onToggleCalendarType={() => {}}
+              onClickTodayMoveBtn={() => {}}
+              onChangeDate={() => {}}
+            />
+            <MonthlyCalendarView year={2024} month={12} date={dayjs().date()} />
+          </div>
+        </div>
+        <div className="bottom-area">
+          <div className="inner">
+            <SubTab title="15.TODAY" />
+            <div className="mission-area">
+              <MissionSummary
+                text="오늘은 필라테스를 1년째 간 날이다. 체지방량이 줄어들었고 근육도 조금 커졌다. 너무 뿌듯하다. 세줄일때 말줄임 세줄일때 말줄임 세줄일때 말줄임 세줄일때 말줄임 세줄일때 말줄임 세줄일때 말줄임 세줄일때 말줄임"
+                typeFull={false}
+                imgSrc="https://picsum.photos/200"
+                missionTexts={[
+                  "일이삼사오육칠팔",
+                  "Monthly에서는 한줄로 노출되도록 해주세용",
+                ]}
+                status="excellent"
+                statusText="완벽했어요"
+              />
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default CalendarMonthlyMission;

--- a/web/src/markup/pages/Calendar/WeeklyMission.tsx
+++ b/web/src/markup/pages/Calendar/WeeklyMission.tsx
@@ -2,15 +2,14 @@ import React from "react";
 import CalendarHeaderView from "@/markup/components/calendar/CalendarHeaderView";
 import WeeklyCalendarView from "@/markup/components/calendar/WeeklyView";
 import DayHeader from "@/markup/components/calendar/DayHeaderView";
-import CategoryLabel from "@/markup/components/CategoryLabel";
-import ProgressListView from "@/markup/components/ProgressListView";
-import Button from "@/markup/components/ButtonView";
+import MissionSummary from "@/markup/components/SummaryView";
+import SubTab from "@/markup/components/SubTab";
 import dayjs from "dayjs";
 import { useCalendar } from "@/hooks/useCalendar";
 
 interface LayoutProps {}
 
-const CalendarWeekly = ({}: LayoutProps) => {
+const CalendarWeeklyMission = ({}: LayoutProps) => {
   const { goalCategories } = useCalendar(dayjs());
   return (
     <div className="wrap">
@@ -36,26 +35,27 @@ const CalendarWeekly = ({}: LayoutProps) => {
         </div>
         <div className="bottom-area">
           <div className="inner">
-            <div className="tab-area">
-              <CategoryLabel items={goalCategories} />
-              <ProgressListView
-                alignment="vertical"
-                progressList={[
-                  { task: "일이삼사오육칠팔", count: 5 },
-                  { task: "걸어서 회사가기", count: 3 },
-                  { task: "우유 한잔 마시기", count: 5 },
-                  { task: "근력 운동 하기", count: 4 },
+            <SubTab title="15.TODAY" />
+            <div className="mission-area">
+              <MissionSummary
+                text="오늘은 필라테스를 1년째 간 날이다. 체지방량이 줄어들었고 근육도 조금 커졌다. 너무 뿌듯하다. 세줄일때 말줄임 세줄일때 말줄임 세줄일때 말줄임 세줄일때 말줄임 세줄일때 말줄임 세줄일때 말줄임 세줄일때 말줄임"
+                typeFull
+                imgSrc="https://picsum.photos/200"
+                missionTexts={[
+                  "일이삼사오육칠팔",
+                  "물 2L 마시기",
+                  "근력 운동 하기",
+                  "책 읽기",
                 ]}
+                status="excellent"
+                statusText="완벽했어요"
               />
             </div>
           </div>
-        </div>
-        <div className="fixed-area">
-          <Button as="a" href="/" label="오늘의 바로미터 작성" />
         </div>
       </main>
     </div>
   );
 };
 
-export default CalendarWeekly;
+export default CalendarWeeklyMission;

--- a/web/src/stories/Markup/components/Summary.stories.tsx
+++ b/web/src/stories/Markup/components/Summary.stories.tsx
@@ -12,21 +12,29 @@ export default meta;
 type Story = StoryObj<typeof Summary>;
 
 export const Default: Story = {
-  args: { 
+  args: {
     text: "오늘 참다 못해 폭식해버렸다. 최근 식단도 잘하고 운동도 곧잘 갔는데 날씨가 좋아지니 참을 수 없었음. 솔직히 존맛이었다.",
     typeFull: false,
-    missionTexts: ["모닝 스트레칭", "필라테스", "하루에 물2L 마시기", "여러개 되면 떨어짐", "일이삼사오육칠팔구십"],
+    missionTexts: [
+      "모닝 스트레칭",
+      "필라테스",
+      "하루에 물2L 마시기",
+      "여러개 되면 떨어짐",
+      "일이삼사오육칠팔구십",
+    ],
     status: "excellent",
     statusText: "완벽했어요",
+    imgSrc: "https://picsum.photos/200",
   },
 };
 
 export const Full: Story = {
-  args: { 
+  args: {
     text: "아침마다 무거웠던 어깨가 한결 가벼워졌다. 필테 선생님이 추천해주신 스트레칭이 효과가 있었던듯ㅎㅎ",
     typeFull: true,
     missionTexts: ["누워있기", "넷플릭스 보기", "쉬기"],
     status: "good",
     statusText: "적당해요",
+    imgSrc: "https://picsum.photos/200",
   },
 };

--- a/web/src/stories/Markup/pages/Calendar/Default.stories.tsx
+++ b/web/src/stories/Markup/pages/Calendar/Default.stories.tsx
@@ -1,5 +1,8 @@
 import CalendarMonthly from "@/markup/pages/Calendar/Monthly";
+import CalendarMonthlyMission from "@/markup/pages/Calendar/MonthlyMission";
 import CalendarWeekly from "@/markup/pages/Calendar/Weekly";
+import CalendarWeeklyMission from "@/markup/pages/Calendar/WeeklyMission";
+
 import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
@@ -17,7 +20,17 @@ export const Monthly: Story = {
   args: {},
 };
 
+export const MonthlyMission: Story = {
+  args: {},
+  render: () => <CalendarMonthlyMission />,
+};
+
 export const Weekly: Story = {
   args: {},
   render: () => <CalendarWeekly />,
+};
+
+export const WeeklyMission: Story = {
+  args: {},
+  render: () => <CalendarWeeklyMission />,
 };

--- a/web/src/styles/abstracts/_variables.scss
+++ b/web/src/styles/abstracts/_variables.scss
@@ -8,7 +8,7 @@ $color-system-gray-gray20: rgba(52, 54, 56, 1);
 $color-system-gray-gray30: rgba(73, 75, 77, 1);
 $color-system-gray-gray40: rgba(92, 97, 102, 1);
 $color-system-gray-gray5: rgba(33, 35, 36, 1);
-$color-system-gray-gray50: rgba(120, 124, 128, 1);
+$color-system-gray-gray50: rgba(121, 124, 128, 1);
 $color-system-gray-gray60: rgba(151, 154, 158, 1);
 $color-system-gray-gray70: rgba(181, 184, 189, 1);
 $color-system-gray-gray80: rgba(195, 196, 199, 1);
@@ -45,7 +45,7 @@ $color-system-yellow-yellow20: rgba(191, 162, 80, 1);
 $color-system-yellow-yellow60: rgba(248, 214, 91, 1);
 $color-system-yellow-yellow90: rgba(253, 243, 197, 1);
 $surface-contents-bg: rgba(26, 26, 26, 1);
-$surface-surface: rgba(20, 20, 20, 1);
+$surface-surface: rgba(15, 15, 15, 1);
 $surface-text-field: rgba(23, 23, 23, 1);
 
 $font-family-en: "Montserrat", system-ui, -apple-system, roboto,

--- a/web/src/styles/base/_layout.scss
+++ b/web/src/styles/base/_layout.scss
@@ -20,6 +20,34 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+
+  &.weekly-view {
+    .contents {
+      flex: none;
+      overflow-y: initial;
+
+      &::after {
+        display: block;
+        position: relative;
+        left: 20px;
+        right: 20px;
+        width: calc(100% - 40px);
+        margin-bottom: 20px;
+        padding-bottom: 20px;
+        border-bottom: 1px solid $color-system-gray-gray10;
+        content: "";
+      }
+    }
+
+    .bottom-area {
+      flex: 1;
+      overflow: auto;
+
+      .inner {
+        padding-top: 0;
+      }
+    }
+  }
 }
 
 .contents {
@@ -31,4 +59,16 @@
   .inner {
     padding: 20px 20px 24px;
   }
+}
+
+.fixed-area {
+  display: flex;
+  justify-content: center;
+  position: fixed;
+  z-index: 20;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 24px;
+  box-sizing: border-box;
 }

--- a/web/src/styles/components/calendar.module.scss
+++ b/web/src/styles/components/calendar.module.scss
@@ -69,20 +69,18 @@
 
 .row {
   display: flex;
+  padding: 0 20px;
 }
 
 .day_header {
   flex: 1;
   font-family: $font-family-en;
+  font-size: 12px;
   font-weight: 300;
   text-align: center;
 }
 
 .calendar {
-  height: 310px;
-  overflow: auto;
-  background: var(--surface, #141414);
-
   .calendar-row {
     display: flex;
   }

--- a/web/src/styles/components/progress.module.scss
+++ b/web/src/styles/components/progress.module.scss
@@ -19,6 +19,8 @@
   }
 
   &-list {
+    margin-top: 24px;
+
     @at-root .tab-area & {
       margin-right: -24px;
     }
@@ -27,7 +29,6 @@
       display: flex;
       overflow-y: auto;
       max-width: 100%;
-      margin-top: 24px;
 
       #{$block}-item {
         flex: 0 0 calc(50% - 10px);
@@ -59,6 +60,7 @@
   &-info {
     display: flex;
     font-size: 14px;
+    line-height: 18px;
   }
 
   &-title {

--- a/web/src/styles/components/subtab.module.scss
+++ b/web/src/styles/components/subtab.module.scss
@@ -1,10 +1,15 @@
 .subtab {
-  margin-bottom: 12px;
+  margin-bottom: 16px;
 
   &.has-border {
     border-bottom: 1px solid $color-system-gray-gray10;
-    margin-bottom: 20px;
     padding-bottom: 20px;
+    margin-bottom: 20px;
+
+    // :global(+ .tab-area) {
+    //   padding-top: 0;
+    //   border-top: 0;
+    // }
   }
 
   .inner {
@@ -17,13 +22,12 @@
     font-family: $font-family-en;
     font-size: 18px;
     font-weight: 700;
-    line-height: 29px;
+    line-height: 22px;
     letter-spacing: -0.03em;
     color: $color-system-gray-gray95;
   }
 
   .btn-more {
     margin-left: auto;
-    padding: 4px 4px 4px 0;
   }
 }

--- a/web/src/styles/components/summary.module.scss
+++ b/web/src/styles/components/summary.module.scss
@@ -23,22 +23,36 @@
   }
 
   .image-wrap {
+    position: relative;
     flex-shrink: 0;
     overflow: hidden;
     margin-left: 12px;
-    border: 1px solid rgba($color-system-gray-gray99, 0.04);
     border-radius: 12px;
+
+    &::before {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      border: 1px solid rgba($color-system-gray-gray99, 0.04);
+      box-sizing: border-box;
+      border-radius: inherit;
+      content: "";
+    }
   }
 
   .summary {
     display: flex;
   }
 
+  .text-wrap {
+    flex: 1;
+  }
+
   .text {
     @include multi-ellipsis(3);
     margin-top: 8px;
     font-size: 15px;
-    color: $color-system-gray-gray60;
+    color: $color-system-gray-gray90;
     line-height: 19px;
     letter-spacing: -0.03px;
   }
@@ -52,7 +66,7 @@
       display: inline-flex;
       align-items: center;
       font-size: 14px;
-      color: $color-system-gray-gray90;
+      color: $color-system-gray-gray60;
       line-height: 18px;
       letter-spacing: -0.03px;
       margin-right: 6px;
@@ -70,7 +84,7 @@
         border-radius: 50%;
         background: $color-system-gray-gray50;
         opacity: 30;
-        content: '';
+        content: "";
       }
       &:last-child {
         &::after {


### PR DESCRIPTION
# 작업 내역
* `Pages/Monthly Mission`, `Pages/Weekly Mission` 생성
* Weekly View 일 때 `main` 에 `weekly-view` 클래스 추가
  * contents, bottom-area 스크롤 영역 & tab 스타일 변경 필요하여 추가
* Button 컴포넌트 수정 (a태그로 변경할 수 있도록 수정)
* Summary 컴포넌트 수정 (img src props로 받을 수 있도록 수정)
* 그 외 자잘한 수정

# `Calendar` 앞으로 수정 필요한 내용
* 요일, day 영역 spacing 수정 (두뇌풀가동 중)

# 다음 작업
* `02. Barometer` 페이지 > 일부(https://www.figma.com/design/WxyZU7jjveQZ7kWIPuRy7k/%EB%B0%94%EB%A1%9C%EB%AF%B8%ED%84%B0-v0.5?node-id=778-53502&t=7pP9N0ieu850zICQ-0)
<img width="383" alt="image" src="https://github.com/user-attachments/assets/87219d38-71b8-4874-aca8-1e566a6ef244" />
