### PR TITLE
calendar markup 적용 및 바로미터 데이터 연동

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -22,6 +22,19 @@ const nextConfig = {
     config.resolve.alias["@images"] = path.resolve(__dirname, "public");
     return config;
   },
+  images: {
+    remotePatterns: [
+      // TODO dev용. 지우기
+      {
+        protocol: "https",
+        hostname: "picsum.photos",
+      },
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/web/src/components/calendar/MissionList.tsx
+++ b/web/src/components/calendar/MissionList.tsx
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
-import React, { useEffect, useMemo } from "react";
-import TodoList from "../todo/TodoList";
+import React, { useMemo } from "react";
+import TodoList, { TodoListAlignmentType } from "../todo/TodoList";
 import Button from "@/markup/components/ButtonView";
 import { useRecoilValue } from "recoil";
 import { currentReportState } from "@/recoils/reports";
@@ -8,17 +8,21 @@ import { ReportType } from "@/types/calendar";
 import BaroMeterReport from "../report/BaroMeterReport";
 import { useCalendar } from "@/hooks/useCalendar";
 
-interface WeeklyListViewProps {
+interface MissionListViewProps {
   selectedDate: dayjs.Dayjs;
   missionTexts: string[];
+  typeFull: boolean;
+  alignment: TodoListAlignmentType;
   report?: ReportType;
 }
 
-const WeeklyListView = ({
+const MissionListView = ({
   selectedDate,
   missionTexts,
+  typeFull,
+  alignment,
   report,
-}: WeeklyListViewProps) => {
+}: MissionListViewProps) => {
   const hasReport = useMemo(() => report !== undefined, [report]);
   return (
     <>
@@ -29,9 +33,10 @@ const WeeklyListView = ({
               report={report!}
               selectedDate={selectedDate}
               missionTexts={missionTexts}
+              typeFull={typeFull}
             />
           ) : (
-            <TodoList selectedDate={selectedDate} alignment="vertical" />
+            <TodoList selectedDate={selectedDate} alignment={alignment} />
           )}
         </div>
       </div>
@@ -44,13 +49,19 @@ const WeeklyListView = ({
   );
 };
 
-interface WeeklyListPageProps {
+interface MissionListPageProps {
+  type: "weekly" | "monthly";
   year: number;
   month: number;
   date: number;
 }
 
-export default function WeeklyList({ year, month, date }: WeeklyListPageProps) {
+export default function MissionList({
+  type,
+  year,
+  month,
+  date,
+}: MissionListPageProps) {
   const selectedDate = useMemo(
     () =>
       dayjs()
@@ -64,8 +75,6 @@ export default function WeeklyList({ year, month, date }: WeeklyListPageProps) {
   const report = useRecoilValue(currentReportState(date));
 
   const missionTexts = useMemo(() => {
-    console.log(goalByIdMapper);
-    console.log(report?.archivedGoalIds);
     const result = report?.archivedGoalIds.map(
       (id) => goalByIdMapper.get(id)?.title
     );
@@ -74,7 +83,15 @@ export default function WeeklyList({ year, month, date }: WeeklyListPageProps) {
       : [];
   }, [report, goalByIdMapper]);
 
-  const viewProps = { selectedDate, report, missionTexts };
+  const viewProps = {
+    selectedDate,
+    report,
+    typeFull: type === "weekly",
+    alignment: (type === "weekly"
+      ? "vertical"
+      : "horizontal") as TodoListAlignmentType,
+    missionTexts,
+  };
 
-  return <WeeklyListView {...viewProps} />;
+  return <MissionListView {...viewProps} />;
 }

--- a/web/src/components/calendar/WeeklyCalendar.tsx
+++ b/web/src/components/calendar/WeeklyCalendar.tsx
@@ -31,7 +31,7 @@ const WeeklyCalendarView = ({
   handleSwipeWeek,
 }: WeeklyCalendarViewProps) => {
   return (
-    <div className={cn("container")} role="grid">
+    <>
       <DayHeader />
       <Swiper
         onSwiper={setSwiper}
@@ -42,17 +42,15 @@ const WeeklyCalendarView = ({
       >
         <SwiperSlide />
         <SwiperSlide>
-          <div role="rowgroup">
-            <Weekly
-              weekDates={calendarDates}
-              activeDate={activeDate}
-              onClickDate={handleClickDate}
-            />
-          </div>
+          <Weekly
+            weekDates={calendarDates}
+            activeDate={activeDate}
+            onClickDate={handleClickDate}
+          />
         </SwiperSlide>
         <SwiperSlide />
       </Swiper>
-    </div>
+    </>
   );
 };
 

--- a/web/src/components/calendar/WeeklyCalendar.tsx
+++ b/web/src/components/calendar/WeeklyCalendar.tsx
@@ -13,8 +13,6 @@ import { getWeeklyDateRange } from "@/utils/calendarUtil";
 dayjs.extend(weekOfYear);
 dayjs.extend(weekYear);
 
-const cn = classNames.bind(scss);
-
 interface WeeklyCalendarViewProps {
   calendarDates: number[];
   activeDate: number;
@@ -95,9 +93,16 @@ export default function WeeklyCalendar({
     setCalendarDates(dates);
   }, [selectedDate]);
 
-  const handleClickDate = (d: number) => {
-    const goalDate = selectedDate.set("date", d);
-
+  const handleClickDate = (newD: number) => {
+    // 기존 날짜와 선택된 날짜가 7일 초과 차이 나면 다른 달
+    const prevD = selectedDate.date();
+    const diff = Math.abs(newD - prevD);
+    let goalDate = selectedDate.set("date", newD);
+    if (diff > 7) {
+      const prevM = selectedDate.month();
+      const newM = prevD > newD ? prevM + 1 : prevM - 1;
+      goalDate = selectedDate.set("month", newM).set("date", newD);
+    }
     if (onChangeDate) {
       onChangeDate(goalDate);
     }

--- a/web/src/components/calendar/WeeklyList.tsx
+++ b/web/src/components/calendar/WeeklyList.tsx
@@ -1,6 +1,7 @@
 import dayjs from "dayjs";
 import React, { useMemo } from "react";
 import TodoList from "../todo/TodoList";
+import Button from "@/markup/components/ButtonView";
 
 interface WeeklyListViewProps {
   selectedDate: dayjs.Dayjs;
@@ -9,30 +10,13 @@ interface WeeklyListViewProps {
 const WeeklyListView = ({ selectedDate }: WeeklyListViewProps) => {
   return (
     <>
-      <div
-        style={{
-          padding: "20px",
-          position: "fixed",
-          right: 0,
-          left: 0,
-          bottom: 0,
-          top: "155.5px",
-        }}
-      >
-        <TodoList selectedDate={selectedDate} />
-        <button
-          style={{
-            position: "fixed",
-            background: "black",
-            color: "white",
-            padding: "10px",
-            left: "50%",
-            transform: "translate(-50%, 0)",
-            bottom: "30px",
-          }}
-        >
-          오늘의 바로미터 작성
-        </button>
+      <div className="bottom-area">
+        <div className="inner">
+          <TodoList selectedDate={selectedDate} alignment="vertical" />
+        </div>
+      </div>
+      <div className="fixed-area">
+        <Button as="a" href="/" label="오늘의 바로미터 작성" />
       </div>
     </>
   );

--- a/web/src/components/calendar/WeeklyList.tsx
+++ b/web/src/components/calendar/WeeklyList.tsx
@@ -1,23 +1,45 @@
 import dayjs from "dayjs";
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import TodoList from "../todo/TodoList";
 import Button from "@/markup/components/ButtonView";
+import { useRecoilValue } from "recoil";
+import { currentReportState } from "@/recoils/reports";
+import { ReportType } from "@/types/calendar";
+import BaroMeterReport from "../report/BaroMeterReport";
+import { useCalendar } from "@/hooks/useCalendar";
 
 interface WeeklyListViewProps {
   selectedDate: dayjs.Dayjs;
+  missionTexts: string[];
+  report?: ReportType;
 }
 
-const WeeklyListView = ({ selectedDate }: WeeklyListViewProps) => {
+const WeeklyListView = ({
+  selectedDate,
+  missionTexts,
+  report,
+}: WeeklyListViewProps) => {
+  const hasReport = useMemo(() => report !== undefined, [report]);
   return (
     <>
       <div className="bottom-area">
         <div className="inner">
-          <TodoList selectedDate={selectedDate} alignment="vertical" />
+          {hasReport ? (
+            <BaroMeterReport
+              report={report!}
+              selectedDate={selectedDate}
+              missionTexts={missionTexts}
+            />
+          ) : (
+            <TodoList selectedDate={selectedDate} alignment="vertical" />
+          )}
         </div>
       </div>
-      <div className="fixed-area">
-        <Button as="a" href="/" label="오늘의 바로미터 작성" />
-      </div>
+      {!hasReport && (
+        <div className="fixed-area">
+          <Button as="a" href="/" label="오늘의 바로미터 작성" />
+        </div>
+      )}
     </>
   );
 };
@@ -30,11 +52,29 @@ interface WeeklyListPageProps {
 
 export default function WeeklyList({ year, month, date }: WeeklyListPageProps) {
   const selectedDate = useMemo(
-    () => dayjs().year(year).month(month).date(date),
+    () =>
+      dayjs()
+        .year(year)
+        .month(month - 1)
+        .date(date),
     [year, month, date]
   );
 
-  const viewProps = { selectedDate };
+  const { goalByIdMapper } = useCalendar(selectedDate);
+  const report = useRecoilValue(currentReportState(date));
+
+  const missionTexts = useMemo(() => {
+    console.log(goalByIdMapper);
+    console.log(report?.archivedGoalIds);
+    const result = report?.archivedGoalIds.map(
+      (id) => goalByIdMapper.get(id)?.title
+    );
+    return result !== undefined && result?.length > 0
+      ? (result as string[])
+      : [];
+  }, [report, goalByIdMapper]);
+
+  const viewProps = { selectedDate, report, missionTexts };
 
   return <WeeklyListView {...viewProps} />;
 }

--- a/web/src/components/report/BaroMeterReport.tsx
+++ b/web/src/components/report/BaroMeterReport.tsx
@@ -9,19 +9,21 @@ interface BaroMeterReportViewProps {
   report: ReportType;
   subTabTitle: string;
   missionTexts: string[];
+  typeFull: boolean;
 }
 
 const BaroMeterReportView = ({
   report,
   subTabTitle,
   missionTexts,
+  typeFull,
 }: BaroMeterReportViewProps) => (
   <>
     <SubTab title={subTabTitle} />
     <div className="mission-area">
       <MissionSummary
         text={report.message ?? ""}
-        typeFull
+        typeFull={typeFull}
         imgSrc="https://images.unsplash.com/photo-1591258370814-01609b341790?q=80&w=3072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
         missionTexts={missionTexts}
         score={report.score}
@@ -34,12 +36,14 @@ interface BaroMeterReportProps {
   report: ReportType;
   selectedDate: dayjs.Dayjs;
   missionTexts: string[];
+  typeFull?: boolean;
 }
 
 export default function BaroMeterReport({
   report,
   selectedDate,
   missionTexts,
+  typeFull = true,
 }: BaroMeterReportProps) {
   const subTabTitle = useMemo(() => {
     const title = selectedDate.isSame(dayjs(), "day")
@@ -48,7 +52,7 @@ export default function BaroMeterReport({
     return `${selectedDate.date()}. ${title}`;
   }, [selectedDate]);
 
-  const viewProps = { report, subTabTitle, missionTexts };
+  const viewProps = { report, subTabTitle, missionTexts, typeFull };
 
   return <BaroMeterReportView {...viewProps} />;
 }

--- a/web/src/components/report/BaroMeterReport.tsx
+++ b/web/src/components/report/BaroMeterReport.tsx
@@ -1,0 +1,54 @@
+import SubTab from "@/markup/components/SubTab";
+import React, { useMemo } from "react";
+import MissionSummary from "@/markup/components/SummaryView";
+import { ReportType } from "@/types/calendar";
+import dayjs from "dayjs";
+import { getDayText } from "@/utils/calendarUtil";
+
+interface BaroMeterReportViewProps {
+  report: ReportType;
+  subTabTitle: string;
+  missionTexts: string[];
+}
+
+const BaroMeterReportView = ({
+  report,
+  subTabTitle,
+  missionTexts,
+}: BaroMeterReportViewProps) => (
+  <>
+    <SubTab title={subTabTitle} />
+    <div className="mission-area">
+      <MissionSummary
+        text={report.message ?? ""}
+        typeFull
+        imgSrc="https://images.unsplash.com/photo-1591258370814-01609b341790?q=80&w=3072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+        missionTexts={missionTexts}
+        score={report.score}
+      />
+    </div>
+  </>
+);
+
+interface BaroMeterReportProps {
+  report: ReportType;
+  selectedDate: dayjs.Dayjs;
+  missionTexts: string[];
+}
+
+export default function BaroMeterReport({
+  report,
+  selectedDate,
+  missionTexts,
+}: BaroMeterReportProps) {
+  const subTabTitle = useMemo(() => {
+    const title = selectedDate.isSame(dayjs(), "day")
+      ? "TODAY"
+      : getDayText(selectedDate);
+    return `${selectedDate.date()}. ${title}`;
+  }, [selectedDate]);
+
+  const viewProps = { report, subTabTitle, missionTexts };
+
+  return <BaroMeterReportView {...viewProps} />;
+}

--- a/web/src/components/todo/TodoList.tsx
+++ b/web/src/components/todo/TodoList.tsx
@@ -6,7 +6,7 @@ import { GoalCategoryType, GoalTypeId } from "@/types/goal";
 import dayjs from "dayjs";
 import React, { createContext, useEffect, useMemo, useState } from "react";
 
-type AlignmentType = "horizontal" | "vertical";
+export type TodoListAlignmentType = "horizontal" | "vertical";
 
 interface TodoListViewProps {
   activeTabTypeId: GoalTypeId | undefined;
@@ -15,7 +15,7 @@ interface TodoListViewProps {
   >;
   progressList: ProgressProps[];
   goalCategories: GoalCategoryType[];
-  alignment?: AlignmentType;
+  alignment?: TodoListAlignmentType;
 }
 
 const TodoListView = ({
@@ -37,7 +37,7 @@ const TodoListView = ({
 
 interface TodoListProps {
   selectedDate: dayjs.Dayjs;
-  alignment?: AlignmentType;
+  alignment?: TodoListAlignmentType;
 }
 
 export default function TodoList({ selectedDate, alignment }: TodoListProps) {

--- a/web/src/components/todo/TodoList.tsx
+++ b/web/src/components/todo/TodoList.tsx
@@ -6,6 +6,8 @@ import { GoalCategoryType, GoalTypeId } from "@/types/goal";
 import dayjs from "dayjs";
 import React, { createContext, useEffect, useMemo, useState } from "react";
 
+type AlignmentType = "horizontal" | "vertical";
+
 interface TodoListViewProps {
   activeTabTypeId: GoalTypeId | undefined;
   setActiveTabTypeId: React.Dispatch<
@@ -13,19 +15,21 @@ interface TodoListViewProps {
   >;
   progressList: ProgressProps[];
   goalCategories: GoalCategoryType[];
+  alignment?: AlignmentType;
 }
 
 const TodoListView = ({
   activeTabTypeId,
-  setActiveTabTypeId,
   progressList,
   goalCategories,
+  alignment = "horizontal",
+  setActiveTabTypeId,
 }: TodoListViewProps) => {
   return (
     <div className="tab-area">
       <TodoListContext.Provider value={{ activeTabTypeId, setActiveTabTypeId }}>
         <CategoryLabel items={goalCategories} />
-        <ProgressListView alignment="horizontal" progressList={progressList} />
+        <ProgressListView alignment={alignment} progressList={progressList} />
       </TodoListContext.Provider>
     </div>
   );
@@ -33,9 +37,10 @@ const TodoListView = ({
 
 interface TodoListProps {
   selectedDate: dayjs.Dayjs;
+  alignment?: AlignmentType;
 }
 
-export default function TodoList({ selectedDate }: TodoListProps) {
+export default function TodoList({ selectedDate, alignment }: TodoListProps) {
   const [activeTabTypeId, setActiveTabTypeId] = useState<
     GoalTypeId | undefined
   >();
@@ -69,9 +74,10 @@ export default function TodoList({ selectedDate }: TodoListProps) {
 
   const viewProps = {
     activeTabTypeId,
-    setActiveTabTypeId,
     progressList,
     goalCategories,
+    alignment,
+    setActiveTabTypeId,
   };
 
   return <TodoListView {...viewProps} />;

--- a/web/src/hooks/useCalendar.ts
+++ b/web/src/hooks/useCalendar.ts
@@ -44,6 +44,7 @@ export const useCalendar = (currentDate: dayjs.Dayjs) => {
   // };
 
   useEffect(() => {
+    console.log("useCalendar useEffect! => " + currentDate);
     const newGoalKey = getGoalStateKey(currentDate);
     if (newGoalKey !== goalKey) {
       setGoalKey(newGoalKey);
@@ -63,6 +64,18 @@ export const useCalendar = (currentDate: dayjs.Dayjs) => {
       fetchGoal();
     }
   }, [currentGoal, currentDate]);
+
+  const goalByIdMapper = useMemo(() => {
+    if (!currentGoal) {
+      return new Map<number, GoalType>();
+    }
+
+    return currentGoal.reduce((map, obj) => {
+      const { monthlyGoalId } = obj;
+      map.set(monthlyGoalId, obj);
+      return map;
+    }, new Map<GoalTypeId, GoalType>());
+  }, [currentGoal]);
 
   const goalByTypeMapper = useMemo(() => {
     if (!currentGoal) {
@@ -91,7 +104,8 @@ export const useCalendar = (currentDate: dayjs.Dayjs) => {
 
   return {
     currentGoal,
-    goalByTypeMapper,
+    goalByIdMapper, // goalId 별 goal mapper
+    goalByTypeMapper, // goalCategoryTypeId 별 goals 목록 mapper
     goalCategories, // 설정된 목표의 goal category 목록
     initBaromters,
   };

--- a/web/src/markup/components/BadgeView.tsx
+++ b/web/src/markup/components/BadgeView.tsx
@@ -1,17 +1,43 @@
-import React from "react";
+import React, { useMemo } from "react";
 import classNames from "classnames/bind";
 import scss from "@/styles/components/badge.module.scss";
 import Image from "next/image";
 import { basePath } from "next.config";
+import { BaroMeterScoreType } from "@/types/barometerType";
 
 const cn = classNames.bind(scss);
 
 export interface BadgeProps {
-  status: "excellent" | "good" | "insufficient" | "poor";
-  statusText: "완벽했어요" | "적당해요" | "노력했어요" | "못했어요";
+  score: BaroMeterScoreType;
 }
 
-export const Badge = ({ status, statusText }: BadgeProps) => {
+export const Badge = ({ score }: BadgeProps) => {
+  const status = useMemo(() => {
+    switch (score) {
+      case 1:
+        return "poor";
+      case 2:
+        return "insufficient";
+      case 3:
+        return "good";
+      default:
+        return "excellent";
+    }
+  }, [score]);
+
+  const statusText = useMemo(() => {
+    switch (score) {
+      case 1:
+        return "못했어요";
+      case 2:
+        return "노력했어요";
+      case 3:
+        return "적당해요";
+      default:
+        return "완벽했어요";
+    }
+  }, [score]);
+
   return (
     <strong className={cn("badge", status)}>
       <Image

--- a/web/src/markup/components/SummaryView.tsx
+++ b/web/src/markup/components/SummaryView.tsx
@@ -18,15 +18,14 @@ export const Summary = ({
   text,
   typeFull,
   missionTexts,
-  status,
-  statusText,
+  score,
   imgSrc,
 }: SummaryProps) => {
   return (
     <div className={cn("summary-wrap", { "type-full": typeFull })}>
       <div className={cn("summary")}>
         <div className={cn("text-wrap")}>
-          <Badge status={status} statusText={statusText} />
+          <Badge score={score} />
           <p className={cn("text")}>{text}</p>
         </div>
         <div className={cn("image-wrap")}>

--- a/web/src/markup/pages/Calendar/MonthlyMission.tsx
+++ b/web/src/markup/pages/Calendar/MonthlyMission.tsx
@@ -34,8 +34,7 @@ const CalendarMonthlyMission = () => {
                   "일이삼사오육칠팔",
                   "Monthly에서는 한줄로 노출되도록 해주세용",
                 ]}
-                status="excellent"
-                statusText="완벽했어요"
+                score={4}
               />
             </div>
           </div>

--- a/web/src/markup/pages/Calendar/WeeklyMission.tsx
+++ b/web/src/markup/pages/Calendar/WeeklyMission.tsx
@@ -47,8 +47,7 @@ const CalendarWeeklyMission = ({}: LayoutProps) => {
                   "근력 운동 하기",
                   "책 읽기",
                 ]}
-                status="excellent"
-                statusText="완벽했어요"
+                score={4}
               />
             </div>
           </div>

--- a/web/src/pages/calendar/monthly.tsx
+++ b/web/src/pages/calendar/monthly.tsx
@@ -15,6 +15,7 @@ import { dehydrate, QueryClient, useQuery } from "@tanstack/react-query";
 import { useAccessTokenValue } from "@/recoils/user";
 import SubTab from "@/markup/components/SubTab";
 import TodoList from "@/components/todo/TodoList";
+import MissionList from "@/components/calendar/MissionList";
 
 interface MonthlyPageViewProps {
   year: number;
@@ -49,13 +50,13 @@ const MonthlyPageView = ({
             />
           </div>
         </div>
-        <div className="bottom-area">
+        <MissionList type="monthly" year={year} month={month} date={date} />
+        {/* <div className="bottom-area">
           <div className="inner">
-            {/* TODO 700px 이하 subTab 소거 */}
             <SubTab title={subTabTitle} hasBorder />
             <TodoList selectedDate={selectedDate} />
           </div>
-        </div>
+        </div> */}
       </main>
     </div>
   );

--- a/web/src/pages/calendar/weekly.tsx
+++ b/web/src/pages/calendar/weekly.tsx
@@ -40,24 +40,31 @@ const WeeklyPageView = ({
   handleChangeDate,
 }: WeeklyPageViewProps) => {
   return (
-    <>
-      <CalendarHeaderView
-        type="weekly"
-        year={year}
-        month={month}
-        isToday={isToday}
-        onToggleCalendarType={handleChangeMonthlyView}
-        onClickTodayMoveBtn={handleClickTodayMoveBtn}
-        onChangeDate={handleChangeDate}
-      />
-      <WeeklyCalendar
-        year={year}
-        month={month}
-        date={date}
-        onChangeDate={handleChangeSelectedDate}
-      />
-      <WeeklyList year={year} month={month} date={date} />
-    </>
+    <div className="wrap">
+      {/* weekly: main에 weekly-view 클래스 추가 (하단 bottom-area가 스크롤 될 수 있도록) */}
+      <main className="main weekly-view">
+        <div className="contents">
+          <div className="calendar-area">
+            <CalendarHeaderView
+              type="weekly"
+              year={year}
+              month={month}
+              isToday={isToday}
+              onToggleCalendarType={handleChangeMonthlyView}
+              onClickTodayMoveBtn={handleClickTodayMoveBtn}
+              onChangeDate={handleChangeDate}
+            />
+            <WeeklyCalendar
+              year={year}
+              month={month}
+              date={date}
+              onChangeDate={handleChangeSelectedDate}
+            />
+          </div>
+        </div>
+        <WeeklyList year={year} month={month} date={date} />
+      </main>
+    </div>
   );
 };
 

--- a/web/src/pages/calendar/weekly.tsx
+++ b/web/src/pages/calendar/weekly.tsx
@@ -6,7 +6,7 @@ import weekOfYear from "dayjs/plugin/weekOfYear";
 import utc from "dayjs/plugin/utc";
 import { useRouter } from "next/router";
 import { getFormatDayjs, getWeeklyDateRange } from "@/utils/calendarUtil";
-import WeeklyList from "@/components/calendar/WeeklyList";
+import WeeklyList from "@/components/calendar/MissionList";
 import "swiper/css";
 import CalendarHeaderView from "@/markup/components/calendar/CalendarHeaderView";
 import { useCalendar } from "@/hooks/useCalendar";
@@ -62,7 +62,7 @@ const WeeklyPageView = ({
             />
           </div>
         </div>
-        <WeeklyList year={year} month={month} date={date} />
+        <WeeklyList type="weekly" year={year} month={month} date={date} />
       </main>
     </div>
   );

--- a/web/src/stories/Markup/components/Badge.stories.tsx
+++ b/web/src/stories/Markup/components/Badge.stories.tsx
@@ -6,15 +6,9 @@ const meta = {
   component: Badge,
   tags: ["autodocs"],
   argTypes: {
-    status: {
+    score: {
       control: {
-        type: 'select',
-        options: ["excellent", "good", "insufficient", "poor"],
-      },
-    },
-    statusText: {
-      control: {
-        type: 'text',
+        type: 1 | 2 | 3 | 4,
       },
     },
   },
@@ -25,28 +19,24 @@ type Story = StoryObj<typeof Badge>;
 
 export const Default: Story = {
   args: {
-    status: "excellent",
-    statusText: "완벽했어요",
+    score: 4,
   },
 };
 
 export const GoodStatus: Story = {
   args: {
-    status: "good",
-    statusText: "적당해요",
+    score: 3,
   },
 };
 
 export const InsufficientStatus: Story = {
   args: {
-    status: "insufficient",
-    statusText: "노력했어요",
+    score: 2,
   },
 };
 
 export const PoorStatus: Story = {
   args: {
-    status: "poor",
-    statusText: "못했어요",
+    score: 1,
   },
 };

--- a/web/src/types/barometerType.ts
+++ b/web/src/types/barometerType.ts
@@ -1,0 +1,1 @@
+export type BaroMeterScoreType = 1 | 2 | 3 | 4;

--- a/web/src/types/calendar.ts
+++ b/web/src/types/calendar.ts
@@ -1,10 +1,12 @@
+import { BaroMeterScoreType } from "./barometerType";
+
 export interface ReportType {
   archivedCount: number;
   archivedGoalIds: number[];
   date: string;
   message?: string;
   photo?: string;
-  score: number;
+  score: BaroMeterScoreType;
 }
 
 export interface CalendarViewType {

--- a/web/src/types/goal.ts
+++ b/web/src/types/goal.ts
@@ -6,11 +6,11 @@ export enum GoalTypeId {
 }
 
 export interface GoalType {
-  id: number;
+  monthlyGoalId: number;
   title: string;
   typeId: number;
   count: GoalTypeId; // 주별 목표 달성 횟수
-  archived: string[]; // ["2024-12-30", "2024-12-31"];
+  archivedDates: string[]; // ["2024-12-30", "2024-12-31"];
 }
 
 export interface GoalStateType {


### PR DESCRIPTION
## 작업 내용
- 마크업 weekly/monthly view 적용
- 바로미터 작성일자에 대한 데이터 연동 및 마크업 적용
- 캘린더 버그 수정
  - 2개의 달이 겹치는 weekly view에서 달이 바뀌는 날짜를 선택할 경우, 월이 제대로 변경되도록 수정